### PR TITLE
hydro compatibility

### DIFF
--- a/fovis_ros/CMakeLists.txt
+++ b/fovis_ros/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(catkin REQUIRED COMPONENTS
   cv_bridge 
   image_geometry 
   tf 
-  pcl
   pcl_ros 
   std_srvs
   message_generation
@@ -19,6 +18,8 @@ find_package(catkin REQUIRED COMPONENTS
   #genmsg)
 
 find_package(OpenCV REQUIRED)
+find_package(PCL 1.7.0 REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
 
 find_package(Boost REQUIRED COMPONENTS signals thread)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -39,6 +40,6 @@ add_executable(fovis_stereo_odometer src/stereo_odometer.cpp)
 
 add_executable(fovis_mono_depth_odometer src/mono_depth_odometer.cpp)
 
-target_link_libraries(fovis_stereo_odometer ${catkin_LIBRARIES} visualization)
-target_link_libraries(fovis_mono_depth_odometer ${catkin_LIBRARIES} visualization)
+target_link_libraries(fovis_stereo_odometer ${catkin_LIBRARIES} ${PCL_LIBRARIES} visualization)
+target_link_libraries(fovis_mono_depth_odometer ${catkin_LIBRARIES} ${PCL_LIBRARIES} visualization)
 

--- a/fovis_ros/launch/fovis_hydro_openni.launch
+++ b/fovis_ros/launch/fovis_hydro_openni.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- This should be the same as used with openni_launch -->
+  <arg name="camera" default="camera" />
+  <node pkg="nodelet" type="nodelet" args="manager" name="nodelet_manager" />
+  <node pkg="nodelet" type="nodelet" name="convert_openni_fovis" 
+        args="load depth_image_proc/convert_metric nodelet_manager">
+    <remap from="image_raw" to="$(arg camera)/depth_registered/sw_registered/image_rect_raw"/>
+    <remap from="image" to="$(arg camera)/depth_registered/image_rect"/>
+  </node>
+  <node pkg="fovis_ros" type="fovis_mono_depth_odometer" name="kinect_odometer" >
+    <remap from="/camera/rgb/image_rect" to="$(arg camera)/rgb/image_rect_mono" />
+    <remap from="/camera/rgb/camera_info" to="$(arg camera)/rgb/camera_info" />
+    <remap from="/camera/depth_registered/camera_info" to="$(arg camera)/depth_registered/sw_registered/camera_info" />
+    <remap from="/camera/depth_registered/image_rect" to="$(arg camera)/depth_registered/image_rect" />
+    <param name="approximate_sync" type="bool" value="True" />
+  </node>
+</launch>


### PR DESCRIPTION
I don't think github allows suggesting a pull to a new branch, but that's what I'm trying to do here - these commits make fovis hydro compatible. Libfovis was fine and didn't need any adjustment, by the way.

These are only minor updates to make fovis_ros compile with hydro's new PCL.

I also added a launch file that works out of the box with openni_launch - something changed in hydro so the depth image was encoded in a way fovis can't deal with.
