### PR TITLE
Fix frame_id in the pose message

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,5 @@ ROS Stack containing a wrapper for fovis, a visual odometry library.
 http://www.ros.org/wiki/fovis for the list of contained packages.
 
 Dependecies: libfovis
+
 apt-get install ros-indigo-libfovis

--- a/README.rst
+++ b/README.rst
@@ -2,3 +2,6 @@ fovis
 ==========
 ROS Stack containing a wrapper for fovis, a visual odometry library. 
 http://www.ros.org/wiki/fovis for the list of contained packages.
+
+Dependecies: libfovis
+apt-get install ros-indigo-libfovis


### PR DESCRIPTION
Hi,

The pose message which describes the robot's current pose is refering to the base_link instead of the odom_frame. I believe the frame_id of this message should refer to the world fixed frame (odom). After changing line 123 in the file odometer_base.hpp from base_link_frame_id_ to odom_frame_id_ everything seems to work. 

Thanks!
Daniel
